### PR TITLE
Fix bugs of using connectioninfo in local certificate provider

### DIFF
--- a/envoy/certificate_provider/certificate_provider.h
+++ b/envoy/certificate_provider/certificate_provider.h
@@ -32,12 +32,12 @@ public:
    * Called when cert is already in cache.
    * @param host supplies host of cert.
    */
-  virtual void onCacheHit(const std::string& host) const PURE;
+  virtual void onCacheHit(const std::string host) const PURE;
   /**
    * Called when cert cache is missed.
    * @param host supplies host of cert.
    */
-  virtual void onCacheMiss(const std::string& host) const PURE;
+  virtual void onCacheMiss(const std::string host) const PURE;
 };
 
 class OnDemandUpdateHandle {
@@ -82,7 +82,7 @@ public:
    * @return OnDemandUpdateHandle the handle which can remove that update callback.
    */
   virtual OnDemandUpdateHandlePtr addOnDemandUpdateCallback(
-      const std::string& cert_name, Envoy::CertificateProvider::OnDemandUpdateMetadataPtr metadata,
+      const std::string cert_name, Envoy::CertificateProvider::OnDemandUpdateMetadataPtr metadata,
       Event::Dispatcher& thread_local_dispatcher, OnDemandUpdateCallbacks& callback) PURE;
 
   /**

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -860,6 +860,9 @@ void ServerConnectionImpl::refreshTransportSocket() {
   auto transport_socket = transport_socket_factory_.createDownstreamTransportSocket();
   std::swap(transport_socket, transport_socket_);
   transport_socket_->setTransportSocketCallbacks(*this);
+  // Currently setSslConnection doesn't allow swapping connectioninfo if old connection info exists
+  // Revisit this when related issues are discovered.
+  //socket_->connectionInfoProvider().setSslConnection(transport_socket_->ssl());
 }
 
 ClientConnectionImpl::ClientConnectionImpl(

--- a/source/extensions/certificate_providers/local_certificate/BUILD
+++ b/source/extensions/certificate_providers/local_certificate/BUILD
@@ -19,7 +19,7 @@ envoy_cc_library(
         "//envoy/event:dispatcher_interface",
         "//envoy/server:transport_socket_config_interface",
         "//source/common/common:callback_impl_lib",
-        "//source/common/common:minimal_logger_lib",
+        "//source/common/common:logger_lib",
         "//source/common/common:utility_lib",
         "//source/common/config:datasource_lib",
         "//source/common/protobuf:message_validator_lib",

--- a/source/extensions/certificate_providers/local_certificate/local_certificate.cc
+++ b/source/extensions/certificate_providers/local_certificate/local_certificate.cc
@@ -2,6 +2,7 @@
 
 #include "envoy/extensions/certificate_providers/local_certificate/v3/local_certificate.pb.h"
 
+#include "source/common/common/logger.h"
 #include "source/common/config/datasource.h"
 #include "source/common/config/utility.h"
 #include "source/common/protobuf/message_validator_impl.h"
@@ -52,14 +53,9 @@ Provider::tlsCertificates(const std::string&) const {
 }
 
 Envoy::CertificateProvider::OnDemandUpdateHandlePtr Provider::addOnDemandUpdateCallback(
-    const std::string&, ::Envoy::CertificateProvider::OnDemandUpdateMetadataPtr metadata,
+    const std::string sni, ::Envoy::CertificateProvider::OnDemandUpdateMetadataPtr metadata,
     Event::Dispatcher& thread_local_dispatcher,
     Envoy::CertificateProvider::OnDemandUpdateCallbacks& callback) {
-
-  // TODO: it seems that worker thread destroyed the objects in connectionInfo during
-  // the process of this function running, we might need to copy the value instead of
-  // passing the metadata pointer
-  std::string sni = metadata->connectionInfo()->sni();
 
   auto handle = std::make_unique<OnDemandUpdateHandleImpl>(
       on_demand_update_callbacks_, sni, callback);
@@ -80,7 +76,8 @@ Envoy::CertificateProvider::OnDemandUpdateHandlePtr Provider::addOnDemandUpdateC
     runOnDemandUpdateCallback(sni, thread_local_dispatcher, true);
   } else {
     // Cache miss, generate self-signed cert
-    main_thread_dispatcher_.post([&] { signCertificate(sni, thread_local_dispatcher); });
+    main_thread_dispatcher_.post([sni, metadata, &thread_local_dispatcher, this] {
+      signCertificate(sni, metadata, thread_local_dispatcher); });
   }
   return handle;
 }
@@ -112,7 +109,8 @@ void Provider::runOnDemandUpdateCallback(const std::string& host,
 
 // TODO: we meed to copy more information of original cert, such as SANs, the whole subject,
 // expiration time, etc.
-void Provider::signCertificate(std::string sni,
+void Provider::signCertificate(const std::string sni,
+                               ::Envoy::CertificateProvider::OnDemandUpdateMetadataPtr metadata,
                                Event::Dispatcher& thread_local_dispatcher) {
   bssl::UniquePtr<BIO> bio(BIO_new_mem_buf(const_cast<char*>(ca_cert_.data()), ca_cert_.size()));
   RELEASE_ASSERT(bio != nullptr, "");
@@ -136,12 +134,7 @@ void Provider::signCertificate(std::string sni,
   X509_REQ_set_version(req, 0);
 
   X509_NAME* x509_name = X509_REQ_get_subject_name(req);
-  const char* szCommon = sni.data();
-  //X509_NAME_add_entry_by_txt(x509_name, "CN", MBSTRING_ASC,
-  //                           reinterpret_cast<const unsigned char*>(szCommon), -1, -1, 0);
-  // reference: https://github.com/openssl/openssl/blob/master/test/v3nametest.c
-  X509_NAME_add_entry_by_NID(x509_name, NID_commonName, MBSTRING_ASC,
-                       reinterpret_cast<const unsigned char*>(szCommon), -1, -1, 0);
+  setSubject(metadata->connectionInfo()->subjectPeerCertificate().data(), x509_name);
   X509_set_subject_name(crt, x509_name);
 
   EVP_PKEY_assign_RSA(key, rsa);
@@ -149,14 +142,24 @@ void Provider::signCertificate(std::string sni,
   X509_REQ_sign(req, key, EVP_sha1()); // return x509_req->signature->length
 
   X509_set_version(crt, 2);
-  std::string prefix = "DNS:";
-  std::string subAltName = prefix + sni;
   auto gens = sk_GENERAL_NAME_new_null();
-  auto ia5 = ASN1_IA5STRING_new();
-  ASN1_STRING_set(ia5, subAltName.c_str(), -1);
-  auto gen = GENERAL_NAME_new();
-  GENERAL_NAME_set0_value(gen, GEN_DNS, ia5);
-  sk_GENERAL_NAME_push(gens, gen);
+
+  for (auto& dns : metadata->connectionInfo()->dnsSansPeerCertificate()) {
+    auto ia5 = ASN1_IA5STRING_new();
+    ASN1_STRING_set(ia5, dns.c_str(), -1);
+    auto gen = GENERAL_NAME_new();
+    GENERAL_NAME_set0_value(gen, GEN_DNS, ia5);
+    sk_GENERAL_NAME_push(gens, gen);
+  }
+
+  for (auto& uri : metadata->connectionInfo()->uriSanPeerCertificate()) {
+    auto ia5 = ASN1_IA5STRING_new();
+    ASN1_STRING_set(ia5, uri.c_str(), -1);
+    auto gen = GENERAL_NAME_new();
+    GENERAL_NAME_set0_value(gen, GEN_URI, ia5);
+    sk_GENERAL_NAME_push(gens, gen);
+  }
+
   X509_add1_ext_i2d(crt, NID_subject_alt_name, gens, 0, 0);
   //X509_EXTENSION* ext =
   //    X509V3_EXT_nconf_nid(nullptr, nullptr, NID_subject_alt_name, subAltName.c_str());
@@ -198,6 +201,28 @@ void Provider::signCertificate(std::string sni,
   runOnDemandUpdateCallback(sni, thread_local_dispatcher, false);
 }
 
+void Provider::setSubject(const std::string& subject, X509_NAME* x509_name) {
+  const std::string delim = ", ";
+  std::string item;
+  size_t start = 0, end = subject.find(delim), pos = 0;
+  for ( ; end != std::string::npos; start = end + 2, end = subject.find(delim, start)) {
+    item = subject.substr(start, end - start);
+    if ((pos = item.find("=")) != std::string::npos) {
+      //X509_NAME_add_entry_by_txt(x509_name, "CN", MBSTRING_ASC,
+      //                           reinterpret_cast<const unsigned char*>(szCommon), -1, -1, 0);
+      // reference: https://github.com/openssl/openssl/blob/master/test/v3nametest.c
+      X509_NAME_add_entry_by_txt(x509_name, item.substr(0, pos).c_str(), MBSTRING_ASC,
+                                 reinterpret_cast<const unsigned char*>(item.substr(pos + 1).c_str()),
+                                 -1, -1, 0);
+    }
+  }
+  item = subject.substr(start, subject.length() - start);
+  if ((pos = item.find("=")) != std::string::npos) {
+    X509_NAME_add_entry_by_txt(x509_name, item.substr(0, pos).c_str(), MBSTRING_ASC,
+                               reinterpret_cast<const unsigned char*>(item.substr(pos + 1).c_str()),
+                               -1, -1, 0);
+  }
+}
 } // namespace LocalCertificate
 } // namespace CertificateProviders
 } // namespace Extensions

--- a/source/extensions/certificate_providers/local_certificate/local_certificate.h
+++ b/source/extensions/certificate_providers/local_certificate/local_certificate.h
@@ -26,7 +26,7 @@ public:
   std::vector<std::reference_wrapper<const envoy::extensions::transport_sockets::tls::v3::TlsCertificate>>
   tlsCertificates(const std::string& cert_name) const override;
   Envoy::CertificateProvider::OnDemandUpdateHandlePtr addOnDemandUpdateCallback(
-      const std::string& cert_name,
+      const std::string cert_name,
       Envoy::CertificateProvider::OnDemandUpdateMetadataPtr metadata,
       Event::Dispatcher& thread_local_dispatcher,
       ::Envoy::CertificateProvider::OnDemandUpdateCallbacks& callback) override;
@@ -55,7 +55,10 @@ private:
                                  Event::Dispatcher& thread_local_dispatcher, bool in_cache = true);
   //void signCertificate(std::string sni, absl::Span<const std::string> dns_sans, const std::string subject,
   //                     Event::Dispatcher& thread_local_dispatcher);
-  void signCertificate(std::string sni, Event::Dispatcher& thread_local_dispatcher);
+  void signCertificate(const std::string sni,
+                       Envoy::CertificateProvider::OnDemandUpdateMetadataPtr metadata,
+                       Event::Dispatcher& thread_local_dispatcher);
+  void setSubject(const std::string& subject, X509_NAME* x509_name);
   Event::Dispatcher& main_thread_dispatcher_;
   std::string ca_cert_;
   std::string ca_key_;

--- a/source/extensions/filters/network/bumping/bumping.cc
+++ b/source/extensions/filters/network/bumping/bumping.cc
@@ -199,6 +199,7 @@ void Filter::onGenericPoolFailure(ConnectionPool::PoolFailureReason reason,
                                   Upstream::HostDescriptionConstSharedPtr host) {
   generic_conn_pool_.reset();
   read_callbacks_->upstreamHost(host);
+  //TODO fix potential segmentation fault issue here
   getStreamInfo().upstreamInfo()->setUpstreamHost(host);
   getStreamInfo().upstreamInfo()->setUpstreamTransportFailureReason(failure_reason);
 
@@ -222,18 +223,19 @@ void Filter::onGenericPoolReady(StreamInfo::StreamInfo*,
                                 const Network::Address::InstanceConstSharedPtr&,
                                 Ssl::ConnectionInfoConstSharedPtr info) {
 
-  // Cert mimick
+  // Request mimick cert from local certificate provider.
   requestCertificate(info);
   upstream_ = std::move(upstream);
   generic_conn_pool_.reset();
   onUpstreamConnection();
-  // read_callbacks_->continueReading();
 }
 
 void Filter::requestCertificate(Ssl::ConnectionInfoConstSharedPtr info) {
+  ENVOY_CONN_LOG(info, "sni: {}", read_callbacks_->connection(), read_callbacks_->connection().requestedServerName());
   config_->main_dispatcher_.post([this, info]() {
     this->on_demand_handle_ = config_->tls_certificate_provider_->addOnDemandUpdateCallback(
-        config_->tls_certificate_name_, std::make_shared<BumpingMetadata>(info),
+        std::string(read_callbacks_->connection().requestedServerName()),
+        std::make_shared<BumpingMetadata>(info),
         read_callbacks_->connection().dispatcher(), *this);
   });
 }
@@ -302,7 +304,7 @@ void Filter::disableIdleTimer() {
   }
 }
 
-void Filter::onCacheHit(const std::string&) const {
+void Filter::onCacheHit(const std::string) const {
   // Re-enable downstream reads and writes
   read_callbacks_->connection().readDisable(false);
   read_callbacks_->connection().write_disable = false;
@@ -310,7 +312,7 @@ void Filter::onCacheHit(const std::string&) const {
   read_callbacks_->continueReading();
 }
 
-void Filter::onCacheMiss(const std::string&) const {
+void Filter::onCacheMiss(const std::string) const {
   // Recreate transport socket to use newly generate certificate
   try{
     dynamic_cast<Envoy::Network::ServerConnectionImpl&>(read_callbacks_->connection()).refreshTransportSocket();

--- a/source/extensions/filters/network/bumping/bumping.h
+++ b/source/extensions/filters/network/bumping/bumping.h
@@ -167,8 +167,8 @@ public:
   }
 
   // CertificateProvider::OnDemandUpdateCallbacks
-  void onCacheHit(const std::string& host) const override;
-  void onCacheMiss(const std::string& host) const override;
+  void onCacheHit(const std::string host) const override;
+  void onCacheMiss(const std::string host) const override;
 
   void requestCertificate(Ssl::ConnectionInfoConstSharedPtr info);
 


### PR DESCRIPTION
Also use subject and san of server cert to generate mimic cert

Signed-off-by: LeiZhang <lei.a.zhang@intel.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
