### PR TITLE
Fix issues of subject and expiration time

### DIFF
--- a/source/extensions/certificate_providers/local_certificate/local_certificate.h
+++ b/source/extensions/certificate_providers/local_certificate/local_certificate.h
@@ -58,13 +58,13 @@ private:
   void signCertificate(const std::string sni,
                        Envoy::CertificateProvider::OnDemandUpdateMetadataPtr metadata,
                        Event::Dispatcher& thread_local_dispatcher);
-  void setSubject(const std::string& subject, X509_NAME* x509_name);
+  void setSubject(absl::string_view subject, X509_NAME* x509_name);
   Event::Dispatcher& main_thread_dispatcher_;
   std::string ca_cert_;
   std::string ca_key_;
   std::string default_identity_cert_;
   std::string default_identity_key_;
-  SystemTime expiration_config_;
+  absl::optional<SystemTime> expiration_config_;
 
   Common::CallbackManager<> update_callback_manager_;
   absl::flat_hash_map<std::string, std::list<OnDemandUpdateHandleImpl*>>


### PR DESCRIPTION
Fix issue of incorrectly copy cert subject to mimic cert. Use cert expiration time when expiration_time config is absent.

Signed-off-by: LeiZhang <lei.a.zhang@intel.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
