### PR TITLE
Fix lacking sni of tls handshake in bumping filter

### DIFF
--- a/source/common/network/transport_socket_options_impl.h
+++ b/source/common/network/transport_socket_options_impl.h
@@ -107,7 +107,7 @@ public:
    * nullptr if nothing is in the filter state.
    */
   static TransportSocketOptionsConstSharedPtr
-  fromFilterState(const StreamInfo::FilterState& stream_info);
+  fromFilterState(const StreamInfo::FilterState& stream_info, absl::string_view sni = absl::string_view(""));
 };
 
 class CommonUpstreamTransportSocketFactory : public UpstreamTransportSocketFactory {

--- a/source/extensions/filters/network/bumping/bumping.cc
+++ b/source/extensions/filters/network/bumping/bumping.cc
@@ -145,8 +145,11 @@ Network::FilterStatus Filter::establishUpstreamConnection() {
 
   auto& downstream_connection = read_callbacks_->connection();
   auto& filter_state = downstream_connection.streamInfo().filterState();
+  // Set transport socket SNI of upstream with downstream SNI
   transport_socket_options_ =
-      Network::TransportSocketOptionsUtility::fromFilterState(*filter_state);
+      Network::TransportSocketOptionsUtility::fromFilterState(
+        *filter_state,
+        downstream_connection.requestedServerName());
 
   if (auto typed_state = filter_state->getDataReadOnly<Network::UpstreamSocketOptionsFilterState>(
           Network::UpstreamSocketOptionsFilterState::key());

--- a/source/extensions/filters/network/bumping/bumping.h
+++ b/source/extensions/filters/network/bumping/bumping.h
@@ -166,6 +166,14 @@ public:
     return &read_callbacks_->connection();
   }
 
+  Network::TransportSocketOptionsConstSharedPtr upstreamTransportSocketOptions() const override {
+    return transport_socket_options_;
+  }
+
+  Network::Socket::OptionsSharedPtr upstreamSocketOptions() const override {
+    return upstream_options_;
+  }
+
   // CertificateProvider::OnDemandUpdateCallbacks
   void onCacheHit(const std::string host) const override;
   void onCacheMiss(const std::string host) const override;


### PR DESCRIPTION
Pass downstream sni to upstream connection in bumping filter

Signed-off-by: LeiZhang <lei.a.zhang@intel.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
