### PR TITLE
Use shared_ptr for certificates cache

### DIFF
--- a/source/extensions/certificate_providers/local_certificate/local_certificate.cc
+++ b/source/extensions/certificate_providers/local_certificate/local_certificate.cc
@@ -30,7 +30,7 @@ Provider::Provider(const envoy::config::core::v3::TypedExtensionConfig& config,
   }
 
   // Generate TLSCertificate
-  envoy::extensions::transport_sockets::tls::v3::TlsCertificate* tls_certificate = new envoy::extensions::transport_sockets::tls::v3::TlsCertificate();
+  TlsCertificateSharedPtr tls_certificate = std::make_shared<envoy::extensions::transport_sockets::tls::v3::TlsCertificate>();
   tls_certificate->mutable_certificate_chain()->set_inline_string(default_identity_cert_);
   tls_certificate->mutable_private_key()->set_inline_string(default_identity_key_);
   // Update certificates_ map
@@ -209,7 +209,7 @@ void Provider::signCertificate(const std::string sni,
   std::string key_pem(reinterpret_cast<const char*>(output), length);
 
   // Generate TLSCertificate
-  envoy::extensions::transport_sockets::tls::v3::TlsCertificate* tls_certificate = new envoy::extensions::transport_sockets::tls::v3::TlsCertificate();
+  TlsCertificateSharedPtr tls_certificate = std::make_shared<envoy::extensions::transport_sockets::tls::v3::TlsCertificate>();
   tls_certificate->mutable_certificate_chain()->set_inline_string(cert_pem);
   tls_certificate->mutable_private_key()->set_inline_string(key_pem);
 

--- a/source/extensions/certificate_providers/local_certificate/local_certificate.h
+++ b/source/extensions/certificate_providers/local_certificate/local_certificate.h
@@ -13,6 +13,9 @@ namespace Extensions {
 namespace CertificateProviders {
 namespace LocalCertificate {
 
+using TlsCertificateSharedPtr =
+    std::shared_ptr<envoy::extensions::transport_sockets::tls::v3::TlsCertificate>;
+
 // Local cert provider
 class Provider : public CertificateProvider::CertificateProvider,
                  Logger::Loggable<Logger::Id::cert_provider> {
@@ -46,8 +49,7 @@ private:
   };
 
   mutable absl::Mutex certificates_lock_;
-  absl::flat_hash_map<std::string,
-                      const envoy::extensions::transport_sockets::tls::v3::TlsCertificate*>
+  absl::flat_hash_map<std::string, TlsCertificateSharedPtr>
       certificates_ ABSL_GUARDED_BY(certificates_lock_);
 
   void runAddUpdateCallback();


### PR DESCRIPTION
Change raw pointers in certificates cache to shared ptr

Signed-off-by: LeiZhang <lei.a.zhang@intel.com>

<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
